### PR TITLE
ci: bump workflow actions off Node 20 and track them with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,18 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # Workflow actions. Majors are deliberately NOT ignored here: for actions a
+  # major is usually just a runner bump (Node 20 -> 24), and skipping them is
+  # what let checkout/setup-node drift three majors behind. Grouped, so this is
+  # one PR however many actions move. Majors will not auto-merge, since
+  # dependabot-auto-merge.yml only handles patch and minor.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,15 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Install pnpm
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # Set up Node.js
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.13.0
           cache: 'pnpm'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Why

CI was emitting this on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v4`.

The forced fallback is temporary. These were **three majors behind** because `dependabot.yml` declared only the `npm` ecosystem and had no `github-actions` entry, so nothing had ever updated them.

## Changes

**1. Bump the actions.**

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `pnpm/action-setup` | v4 | v6 |
| `dependabot/fetch-metadata` | v2 | v3 |

**2. Add a `github-actions` ecosystem to `dependabot.yml`** so this cannot silently recur.

Majors are deliberately **not** ignored for this ecosystem, unlike npm. For actions a major is usually just a runner bump, and those are exactly the updates that matter. Ignoring them would recreate the drift this is meant to prevent. Grouped under a single `actions` group, so it is one PR however many actions move, realistically a few times a year.

Majors still will not auto-merge, since `dependabot-auto-merge.yml` only handles patch and minor. That split is intentional: a major like `checkout` v7 deserves a human read before landing.

## Breaking-change review

Every major was checked against its release notes rather than bumped blind. Two could plausibly have broken this repo:

- **`checkout` v7 blocks fork-PR checkout under `pull_request_target`.** `dependabot-auto-merge.yml` uses exactly that trigger, but it has **no checkout step**, and `ci.yml` checks out under `pull_request`. Not affected.
- **`setup-node` v5 auto-enables caching when `packageManager` is set** (root manifest has `pnpm@10.28.1`), and **v6 narrows auto-caching to npm**. Both affect only *automatic* caching. The explicit `cache: 'pnpm'` input is unchanged, and `pnpm/action-setup` still runs first so the store path resolves before `setup-node` reads it.

The rest were runtime-only: `checkout` v5 (Node 24, needs runner >= v2.327.1, which GitHub-hosted runners exceed), v6 (credentials to a separate file); `pnpm/action-setup` v5 (Node 24), v6 (pnpm v11 support); `fetch-metadata` v3 (Node 24, outputs unchanged so the `update-type` check still resolves).

## Verification

The `build` job exercises checkout, `pnpm/action-setup`, and `setup-node` including pnpm cache restore. If the cache input or store path broke, install would fail. The prior run on this branch passed and **emitted zero annotations**, versus the Node 20 deprecation warning on the last run on `main`.

Not covered by this PR:

- **`dependabot/fetch-metadata@v3`** — `pull_request_target` runs the workflow from the base branch, so it takes effect only after merge and is first exercised on the next Dependabot PR.
- **The `github-actions` ecosystem entry** — config is parsed server-side by GitHub after it lands on the default branch.

## Note on why these are one PR

A PR touching only `.github/dependabot.yml` matches `ci.yml`'s `paths-ignore` (`.github/**`, with only `!.github/workflows/**` negated), so no CI run is created, the required `build` check stays pending, and the PR can never merge. Bundling it with the workflow change keeps CI running.