### PR TITLE
docs: refresh stale version badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Stars](https://img.shields.io/github/stars/ProductOfAmerica/turbo-starter?style=social)](https://github.com/ProductOfAmerica/turbo-starter)
 [![Node.js](https://img.shields.io/badge/Node.js-v24.13.0+-green)](https://nodejs.org/)
 [![pnpm](https://img.shields.io/badge/pnpm-v10.28.1-orange)](https://pnpm.io/)
-[![nextjs](https://img.shields.io/badge/Next.js-16.1.6-blue?logo=nextdotjs)](https://nextjs.org/)
-[![tailwindcss](https://img.shields.io/badge/TailwindCSS-4.1.18-38B2AC?logo=tailwind-css)](https://tailwindcss.com/)
+[![nextjs](https://img.shields.io/badge/Next.js-16.2.12-blue?logo=nextdotjs)](https://nextjs.org/)
+[![tailwindcss](https://img.shields.io/badge/TailwindCSS-4.3.3-38B2AC?logo=tailwind-css)](https://tailwindcss.com/)
 [![Build Status](https://github.com/ProductOfAmerica/turbo-starter/actions/workflows/ci.yml/badge.svg)](https://github.com/ProductOfAmerica/turbo-starter/actions)
 
 A modern, turbocharged monorepo template for building Next.js apps with ease. Packed with **Next.js 16**, **Turborepo**,


### PR DESCRIPTION
The Next.js and Tailwind badges advertised 16.1.6 and 4.1.18 while the repo is on 16.2.12 and 4.3.3. For a template people evaluate before cloning, badges that understate the stack are misleading.

Node and pnpm badges already matched and are left alone.

Note: this PR touches only `README.md`, which is also serving as a deliberate test of whether `ci.yml`'s `paths-ignore` leaves the required `build` check permanently pending.