### PR TITLE
ci: always run the required build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,21 @@
 name: CI
 
-# Trigger the workflow on push and pull requests to the main branch
+# Trigger the workflow on push and pull requests to the main branch.
+#
+# Deliberately no paths-ignore. "build" is a required status check, and a
+# path-filtered workflow produces no run at all, so the check never reports and
+# branch protection blocks the PR forever. There is no recovery: any follow-up
+# commit that is also docs-only stays filtered too.
+#
+# Verified on PR #176 (README-only): mergeable=MERGEABLE, state=BLOCKED, every
+# other check green, and no "build" check ever created. Skipping buys nothing
+# anyway, since Actions minutes are free on a public repo and Vercel and CodeQL
+# do not honour this filter, so they build regardless.
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.vscode/**'
-      - '.idea/**'
-      - 'docs/**'
-      - '.github/**'
-      - '!.github/workflows/**'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.vscode/**'
-      - '.idea/**'
-      - 'docs/**'
-      - '.github/**'
-      - '!.github/workflows/**'
 
 # Cancel superseded PR runs; Dependabot force-pushes a rebase on every lockfile conflict.
 # Push events key on SHA so main-branch runs are never cancelled.


### PR DESCRIPTION
## The bug

`build` is a **required status check**, but `ci.yml` filtered it with `paths-ignore`. A path-filtered workflow creates **no run at all**, so the check never reports and branch protection blocks the PR permanently.

There is no recovery path. GitHub's documented workaround for skipped-but-required checks is *"push a new commit to the pull request without the skip instruction in the commit message"*, which does not apply to path filters: any follow-up docs-only commit is filtered identically. The only escapes are an admin bypass or deliberately adding an unrelated non-docs file to the PR.

## Proof

Demonstrated on #176, a README-only change:

| Signal | Value |
|---|---|
| `mergeable` | `MERGEABLE` (no conflicts) |
| `mergeStateStatus` | **`BLOCKED`** |
| `build` check | **never created** — not pending, absent entirely |
| `Analyze (actions)` | pass |
| `Analyze (javascript-typescript)` | pass |
| `CodeQL` | pass |
| `Vercel` | pass, deployment completed |

Every check that exists is green, the merge is clean, and the PR cannot be merged.

## Why skipping bought nothing

- **Actions minutes are free** on a public repo, so the filter saved no money.
- **Vercel does not honour it.** It ran a full preview deployment on that README-only PR. Vercel has its own Ignored Build Step and never reads GitHub path filters.
- **CodeQL does not honour it** either; it has separate configuration.

So the only thing `paths-ignore` suppressed was the free job, in exchange for an unmergeable pull request.

## Why this matters extra for a template

Anyone who forks this repo and turns on branch protection, which is a normal thing to do, inherits the trap and hits it on their first README PR. Shipping that in a starter is worse than running CI on doc changes.

## Cost

About 90 seconds of free compute on docs-only changes. The trigger block is now four lines instead of twenty, with a comment recording why it must stay that way.

## Follow-up

Once this lands, #176 gets rebased. The `build` check should appear and it should become mergeable, closing the loop on the proof.