### PR TITLE
ci: skip the build job on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,17 @@
 name: CI
 
-# Trigger the workflow on push and pull requests to the main branch.
+# Trigger on every push and pull request to main.
 #
 # Deliberately no paths-ignore. "build" is a required status check, and a
 # path-filtered workflow produces no run at all, so the check never reports and
-# branch protection blocks the PR forever. There is no recovery: any follow-up
-# commit that is also docs-only stays filtered too.
+# branch protection blocks the PR forever, with no recovery: any follow-up
+# commit that is also docs-only stays filtered too. Verified on PR #176
+# (README-only): mergeable=MERGEABLE, state=BLOCKED, no "build" check created.
 #
-# Verified on PR #176 (README-only): mergeable=MERGEABLE, state=BLOCKED, every
-# other check green, and no "build" check ever created. Skipping buys nothing
-# anyway, since Actions minutes are free on a public repo and Vercel and CodeQL
-# do not honour this filter, so they build regardless.
+# Docs-only changes are skipped at the JOB level instead. That still creates a
+# check run, and per GitHub, "required status checks must have a successful,
+# skipped, or neutral status", so a skipped job satisfies branch protection
+# while a missing one blocks it.
 on:
   push:
     branches: [ main ]
@@ -25,7 +26,57 @@ concurrency:
 
 # Jobs to run
 jobs:
+  # Decide whether anything outside docs changed. Fails safe: if the base commit
+  # cannot be resolved (first push, force-push, shallow clone), assume code
+  # changed and run the whole pipeline. Skipping requires positive evidence.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-docs changes
+        id: filter
+        env:
+          # Only ever interpolate SHAs here, never branch names or PR titles,
+          # which are attacker-controlled and would be a script-injection vector.
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base commit unresolvable; running the full pipeline."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          if [ -z "$CHANGED" ]; then
+            echo "No diff against base; running the full pipeline."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # code=true if ANY changed path is not documentation.
+          if printf '%s\n' "$CHANGED" | grep -qvE '(\.md$|^LICENSE$|^\.vscode/|^\.idea/|^docs/)'; then
+            echo "Non-docs changes present; running the full pipeline."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs-only change; skipping build."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
## Why

Removing `paths-ignore` in #177 fixed the deadlock but overcorrected. A README edit now runs a full install, audit, lint, typecheck, build and Playwright suite: roughly 90 seconds of work that cannot possibly be affected by a markdown change.

Both goals are reachable, because these are **different states** to branch protection:

| | Check run | Required check |
|---|---|---|
| Workflow path-filtered | **none created** | blocks forever (proven on #176) |
| Job skipped via `if:` | **created, `SKIPPED`** | **satisfied** |

Per GitHub's branch protection docs: *"Required status checks must have a `successful`, `skipped`, or `neutral` status before collaborators can make changes to a protected branch."*

This repo already demonstrates the mechanism: the `auto-merge` job reports `COMPLETED`/`SKIPPED` on every non-Dependabot PR.

## How

The workflow always triggers. A small `changes` job decides whether `build` runs at all.

Detection is a plain `git diff` rather than a third-party action, so CI's trust boundary is unchanged. Worth noting that `tj-actions/changed-files`, a popular action in this category, was supply-chain compromised in 2025; this repo runs `pnpm audit`, CodeQL and secret scanning, so not widening that surface for a path comparison seems right.

**It fails safe.** If the base commit cannot be resolved (first push, force-push, shallow clone), it assumes code changed and runs everything. Skipping requires positive evidence that *every* changed path is documentation.

Only `*.md`, `LICENSE`, `.vscode/`, `.idea/` and `docs/` skip. **`.github/` is deliberately not treated as docs**, so config and workflow edits still get a full run.

Only SHAs are interpolated into the shell step, never branch names or PR titles, which are attacker-controlled and are the usual script-injection vector in Actions.

## Verification

The filter logic was unit-tested locally against 13 path combinations before pushing:

| Input | Result |
|---|---|
| `README.md` | skip |
| `README.md` + `CLAUDE.md` | skip |
| `docs/guide.md`, `LICENSE`, `.vscode/settings.json`, `apps/web/README.md` | skip |
| **`README.md` + `package.json`** | **run** (mixed is conservative) |
| `package.json`, `pnpm-lock.yaml`, `apps/web/src/page.tsx` | run |
| `.github/dependabot.yml`, `.github/workflows/ci.yml` | run |
| **`LICENSE.txt`** | **run** (anchored `^LICENSE$` does not over-match) |

**This PR is itself the positive test**: it changes `.github/workflows/ci.yml`, so `changes` should emit `code=true` and `build` should run normally.

The negative test needs a separate docs-only PR after this lands. Expected result: `build` reports `SKIPPED` and the PR is `CLEAN`, not `BLOCKED`. That is the case #176 proved was broken, so it is worth confirming rather than assuming.

The `build` job id is unchanged, so the required check context still matches.