### PR TITLE
docs: document the start and test:e2e commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,12 @@ npx turbo link
 |---------|-------------|
 | `pnpm dev` | Start the dev server |
 | `pnpm build` | Build all apps and packages |
+| `pnpm start` | Serve the production build |
 | `pnpm lint` | Check for lint and format issues |
 | `pnpm lint:fix` | Auto-fix lint issues |
 | `pnpm check-types` | TypeScript type checking |
 | `pnpm format-write` | Format code |
+| `pnpm test:e2e` | Run the Playwright E2E suite |
 
 ---
 


### PR DESCRIPTION
`pnpm start` and `pnpm test:e2e` both exist in the root `package.json` but were missing from the README Commands table. A reader could build the app without learning how to serve it, and would not discover the Playwright suite at all.

---

This PR is also the **negative test** for #178. It touches only `README.md`, so the `changes` job should emit `code=false` and `build` should report `SKIPPED`.

Expected: `build: SKIPPED`, merge state `CLEAN`.

If it comes back `BLOCKED`, the approach in #178 is wrong and should be reverted to always-running, since that would be a subtler version of the #176 deadlock.