### PR TITLE
fix(biome): respect .gitignore so generated files stop failing pre-commit

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",
@@ -10,7 +15,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"suspicious": {
 				"noExplicitAny": "warn"
 			},
@@ -40,17 +45,7 @@
 		}
 	},
 	"files": {
-		"includes": [
-			"**",
-			"!**/node_modules",
-			"!**/dist",
-			"!**/.next",
-			"!**/.turbo",
-			"!**/apps/web/out",
-			"!**/.claude",
-			"!**/test-results",
-			"!**/playwright-report"
-		]
+		"includes": ["**"]
 	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"overrides": [
@@ -59,7 +54,7 @@
 			"linter": {
 				"rules": {
 					"a11y": {
-						"recommended": true
+						"preset": "recommended"
 					},
 					"correctness": {
 						"useJsxKeyInIterable": "error"
@@ -72,7 +67,7 @@
 			"linter": {
 				"rules": {
 					"a11y": {
-						"recommended": true,
+						"preset": "recommended",
 						"useKeyWithClickEvents": "error",
 						"useValidAnchor": "error"
 					},


### PR DESCRIPTION
## The bug

`biome.json` had no `vcs` block, so Biome never read `.gitignore` and linted generated output.

`pnpm build` regenerates `apps/web/next-env.d.ts` with double quotes, Biome demands single quotes, and the lefthook `pre-commit` hook rejects the commit. The file is gitignored and untracked, so the developer neither wrote it nor can see it in `git status`. It blocked two commits while working in this repo.

**CI never caught it** because `ci.yml` runs lint *before* build, so the file does not exist yet on a runner. It only reproduces locally, and only after a build, which is exactly the path a new contributor takes. For a template repo, that is an onboarding trap.

## Measured, with `next-env.d.ts` present on disk

| | Files checked | Errors | Infos | Exit |
|---|---|---|---|---|
| before | 100 | **1** | 2 | **1** |
| after | **99** | **0** | **0** | **0** |

End-to-end: `pnpm build` → `pnpm lint` → `git commit` now succeeds. That sequence failed before this change.

## Why it works

The fix depends on Biome honouring **nested** ignore files, since `next-env.d.ts` is listed in `apps/web/.gitignore`, not the root one. Per Biome's configuration reference, `useIgnoreFile` *"supports nested ignore files"*. Checked before implementing, because without nested support this change would do nothing.

`vcs.root` is omitted deliberately: it defaults to the directory holding `biome.json`, which is already the repo root.

## Two diagnostics folded in

Both fired on every `pnpm lint` and every commit.

**Deprecated `recommended` field.** Used `biome migrate` rather than hand-editing. It rewrote **all three** occurrences: the top-level one plus both `a11y` blocks in `overrides`. Only the top-level was warning, so hand-editing would have silently left the other two behind. `PresetConfig` is a string enum (`recommended` / `all` / `none`), so the mapping is one-to-one with no rule-set change.

**`$schema` version mismatch.** Now points at `./node_modules/@biomejs/biome/configuration_schema.json` instead of a pinned URL. `biome migrate` pins it to the current version, but Dependabot bumps `@biomejs/biome` in `package.json` and never touches the URL inside `biome.json`, so a pinned value drifts again on the very next bump. The relative path tracks whatever is installed. Trade-off: on a fresh clone before `pnpm install`, editors show the schema unresolved.

## `files.includes` reduced to `["**"]`

All eight exclusions (`node_modules`, `dist`, `.next`, `.turbo`, `apps/web/out`, `.claude`, `test-results`, `playwright-report`) were already covered by the root `.gitignore`, so `.gitignore` becomes the single source of truth for what is generated. Gated on verification: checked-file count is unchanged at 99, confirming nothing new came into scope.

## Note on `pnpm lint:ci` locally

It fails on Windows both before and after this change. The working tree is CRLF by design (`"lineEnding": "crlf"`) while `lint:ci` forces LF for Linux runners, and `.gitattributes` normalises to LF in the repo.

Compared **uncapped** diagnostics (Biome truncates at 20 by default, which made a first attempt at this comparison misleading):

- old config: **100** files fail `--line-ending=lf`
- new config: **99**
- regressions: **none**; `next-env.d.ts` is the only file removed

## Out of scope

The pre-existing `suppressions/unused` warning at `apps/web/e2e/homepage.spec.ts:68` remains. Unrelated to Biome config and its own decision.