### PR TITLE
chore: drop two pieces of dead config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 
 # Force specific files to have LF line endings on checkout
 *.sh text eol=lf
-biome.ci.json text eol=lf
 
 # These files are always treated as binary
 *.jpg binary

--- a/apps/web/e2e/homepage.spec.ts
+++ b/apps/web/e2e/homepage.spec.ts
@@ -65,7 +65,6 @@ test.describe('Homepage rendering', () => {
 
 	// Skip screenshot comparison in CI (font rendering differs across OS)
 	// Run locally with: npx playwright test --grep "screenshot"
-	// biome-ignore lint/correctness/noUnusedFunctionParameters: fixture triggers navigation
 	test.skip(!!process.env.CI, 'Screenshot baselines are platform-specific');
 	test('full page screenshot matches baseline', async ({ page, _homePage }) => {
 		await expect(page).toHaveScreenshot('homepage.png', {


### PR DESCRIPTION
Two leftovers, both verified dead rather than assumed.

## 1. `.gitattributes` rule for a deleted file

```diff
  *.sh text eol=lf
- biome.ci.json text eol=lf
```

`biome.ci.json` genuinely existed and was removed in `bcad0db` *("Remove biome.ci.json to fix line endings")*. The `.gitattributes` rule outlived the file.

Removing it is inert: `git status` after the edit shows only the two intended files, no renormalization.

## 2. A `biome-ignore` that Biome itself flagged as useless

```diff
  // Skip screenshot comparison in CI (font rendering differs across OS)
  // Run locally with: npx playwright test --grep "screenshot"
- // biome-ignore lint/correctness/noUnusedFunctionParameters: fixture triggers navigation
  test.skip(!!process.env.CI, 'Screenshot baselines are platform-specific');
```

Biome reported `suppressions/unused` here on every lint and every commit. It was dead for **two** independent reasons:

1. **Wrong target.** A suppression applies to the next statement, which is `test.skip(...)`. That call takes no function parameters at all. The `_homePage` parameter it claimed to suppress is on the line *after* that, in the `test(...)` callback.
2. **Unnecessary regardless.** Biome skips underscore-prefixed parameters, so `noUnusedFunctionParameters` would never have fired on `_homePage` anyway.

The proof for (2) is in the same file: seven other tests destructure the identical `{ page, _homePage }` with no suppression and lint clean. Deleting the line produced no new diagnostic, which confirms it rather than assuming it.

Only the suppression is gone. The two comments above it explain why the screenshot test is skipped in CI and are worth keeping.

## Verification

- `biome check .` → **99 files, no findings at all**, exit 0. First time the repo lints completely clean.
- `pnpm check-types` → passes
- `CI=true npx playwright test` → 10 passed, 8 skipped, unchanged
- `git status` → no line-ending renormalization from the `.gitattributes` edit