### PR TITLE
ci: audit main weekly, since auto-merged pushes never run CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,26 @@ name: CI
 # check run, and per GitHub, "required status checks must have a successful,
 # skipped, or neutral status", so a skipped job satisfies branch protection
 # while a missing one blocks it.
+#
+# The weekly schedule exists because auto-merged pushes do not run CI at all.
+# dependabot-auto-merge.yml merges with GITHUB_TOKEN, and GitHub suppresses
+# workflow runs for events it triggers, to avoid recursion. Between 2026-04-10
+# and 2026-07-25 that meant 145 commits landed on main and produced zero CI
+# runs, so `pnpm audit` never re-checked main. Four high-severity next
+# advisories published on ~2026-07-21 sat undetected until a human push on
+# 07-25 happened to run the audit.
+#
+# Dependabot alerts now catch most of this on their own, but not the case where
+# no fix exists for it to open a PR with. This is the backstop for that.
+# Dependabot lands its batch on Sunday, so run midweek to halve the worst-case
+# window. The minute is offset because GitHub delays scheduled runs that are
+# queued on the hour.
 on:
+  schedule:
+    - cron: '23 6 * * 4'
+  # Same base-less code path as `schedule`, so the scheduled behaviour can be
+  # exercised on demand instead of waiting a week.
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:


### PR DESCRIPTION
## The finding

`dependabot-auto-merge.yml` merges with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, and GitHub suppresses workflow runs for events its own token triggers, to prevent recursion:

> "When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run"

So **auto-merged dependency bumps land on main without ever running CI.**

Measured over 2026-04-10 to 2026-07-25: **145 commits landed, 0 push-event CI runs.**

### Controlled proof

Four merges from last night, minutes apart, identical config, split only by who merged:

| Commit | PR | Merged by | Runs on that SHA |
|---|---|---|---|
| `02af312` | #174 | me | `CI event=push actor=ProductOfAmerica` |
| `37a5ac8` | #175 | me | `CI event=push actor=ProductOfAmerica` |
| `d08b121` | #169 | auto-merge | **no CI**, only `actor=github-actions[bot]` |
| `8b22577` | #170 | auto-merge | **no CI**, only `actor=github-actions[bot]` |

`paths-ignore` was never the cause. I had previously suspected it; this rules it out.

## Why it mattered

`ci.yml` had no `schedule`, so `pnpm audit` never re-checked main. That is exactly how four high-severity `next` advisories published around 2026-07-21 went unnoticed until a human push on 07-25 happened to run the audit. Main was vulnerable for four days and was caught by accident.

## Why weekly and not daily

Enabling Dependabot alerts and security updates already covers most of this: a new advisory now opens a PR, and that PR runs the audit itself.

The gap this closes is narrower — when **no fix exists**, Dependabot has no PR to open, and main stays green while actually failing the audit. Not theoretical: #171, #172 and #173 all failed CI last night because the vulnerable `postcss` was pinned transitively by `next` and unreachable.

So this is a backstop behind Dependabot alerts, not the primary detector, and detection latency matters much less than it would if it were the only signal. Daily would be cargo-culted frequency.

**Thursday**, because Dependabot lands its batch on **Sunday** (measured: 55 of its last 60 PRs), so midweek roughly halves the worst-case window either side. The cron minute is offset from the hour because GitHub delays scheduled runs queued at peak.

## `workflow_dispatch`

A scheduled run has neither `pull_request.base.sha` nor `github.event.before`, so `BASE_SHA` is empty, the `changes` job takes its fail-safe path, and the full pipeline runs. That is the intended behaviour for an audit, and **no extra guard was needed** — the existing fail-safe already handles it.

`workflow_dispatch` is base-less in exactly the same way, so it exercises that path on demand rather than requiring a week to observe. It gets used to verify this PR after merge.

## Deliberately unchanged

Concurrency. A scheduled run can share a group with a push run on the same SHA, but both validate an identical tree, so the cancellation is dedup rather than lost coverage.

## Verification after merge

Trigger `workflow_dispatch` and confirm the `changes` job logs "Base commit unresolvable; running the full pipeline" and that `build` runs rather than skipping.