### PR TITLE
fix(deps): bump nanoid to 3.3.18 so the audit gate passes again

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1860,8 +1860,8 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3518,7 +3518,7 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -3567,7 +3567,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## What broke

`pnpm audit --audit-level=high` fails on `main`. Latest hit is the weekly scheduled run, [31679882748](https://github.com/ProductOfAmerica/turbo-starter/actions/runs/31679882748):

```
high  nanoid: custom generators can loop indefinitely when size is zero
Vulnerable versions <3.3.17 | Patched >=3.3.17
Paths  apps__web>@tailwindcss/postcss>postcss>nanoid
```

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), published 2026-07-29. No commit introduced this; the advisory database moved and the pinned `nanoid@3.3.16` fell behind it.

## Why it matters beyond the schedule

Dependabot PRs #185 and #186 have been red on this same finding since 2026-08-09. `build` is a required check, so auto-merge never fired and both stalled. Merging this should unblock them after a rebase.

The GitHub alert for this only appeared on 2026-08-12, two weeks after the advisory went public, and no Dependabot security PR had opened by 2026-08-13. Worth noting that `cooldown` is not the reason: per GitHub's docs it applies to version updates only, never security updates.

## The change

`postcss@8.5.23` already declares `nanoid: ^3.3.16`, so the patched release fits inside the existing range. That reduces the fix to a lockfile refresh. No `overrides` entry, no `package.json` edit, no parent bump.

```
pnpm update nanoid --depth Infinity -r
```

Four lines in `pnpm-lock.yaml`, `3.3.16` to `3.3.18`.

## Verification

Run locally against this branch:

- `pnpm audit --audit-level=high` → `No known vulnerabilities found`
- `pnpm check-types` → pass
- `pnpm build` → pass

`lint:ci` is not runnable on a Windows checkout: `core.autocrlf=true` rewrites the worktree to CRLF while the command pins `--line-ending=lf`. The committed blobs are LF, so the Linux runner is unaffected. CI on this PR is the real check.
