### PR TITLE
docs: add a security policy that matches how this repo actually ships

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+This is a template repository, not a published package. It has no releases, no
+tags, and no version branches, so there is nothing to backport a fix to.
+
+Only `main` is supported. Fixes land there and nowhere else.
+
+If you generated a project from this template, your copy is a fork in practice.
+It does not receive updates from here, and keeping it current is up to you.
+
+## Scope
+
+In scope, because these ship as defaults to everyone who clones the template:
+
+- The security headers in `apps/web/src/proxy.ts` (CSP, HSTS, and the rest)
+- `apps/web/Dockerfile` and `docker-compose.yml`
+- The GitHub Actions workflows in `.github/workflows/`, especially script
+  injection through untrusted event inputs
+- Any committed secret, or a default that causes one to leak
+
+Out of scope:
+
+- Advisories against transitive dependencies. `pnpm audit --audit-level=high`
+  already gates every CI run and Dependabot opens the update PRs. If you spot a
+  stale lockfile entry, open a normal issue or PR rather than a security report.
+- Vulnerabilities in Next.js, Turborepo, shadcn/ui, or Biome themselves. Those
+  belong upstream with their own maintainers.
+- Findings in a project you generated from this template, unless the flaw is in
+  code the template gave you.
+
+## Reporting a Vulnerability
+
+Report privately through GitHub:
+
+**https://github.com/ProductOfAmerica/turbo-starter/security/advisories/new**
+
+That opens a thread visible only to maintainers. Please do not open a public
+issue for a vulnerability.
+
+Include enough to reproduce it: the affected file, the steps, and what an
+attacker gains.
+
+This project is maintained by one person, so treat these as targets rather than
+guarantees. Expect an acknowledgement within a week. Accepted reports are fixed
+on `main` and credited in the published advisory, unless you would rather stay
+anonymous. Declined reports get a reason, not silence.


### PR DESCRIPTION
Fills in the empty "Security policy" slot GitHub reports under Security and quality. Written from scratch rather than from the default template, because two parts of that template are actively wrong for this repo.

## Why not the default template

**The "Supported Versions" table is fiction here.** It ships with rows for `5.1.x`, `5.0.x`, `4.0.x`. This repo has 0 tags and 0 releases, and `package.json` says `2.0.0`, which is published nowhere. Every row would be invented, and the table's whole purpose is to promise backports to versions that do not exist. Replaced with the true statement: only `main` is supported, and a project generated from the template is a fork that updates itself.

**The template has no scope section at all.** That matters more than usual here. CI gates on `pnpm audit --audit-level=high`, so anyone who clones this and runs an audit will eventually hit an upstream advisory, exactly like the `nanoid` one in #187. With no stated scope those arrive as vulnerability reports when Dependabot already covers them. The flip side is worth stating too: a flaw in the defaults this template hands to every clone, meaning `apps/web/src/proxy.ts`, the Docker setup, and the workflows, is the report that genuinely matters, and nothing in the default template invites it.

## Reporting channel

Points at GitHub private vulnerability reporting, which is already enabled on this repo, so the advisory intake URL is linked directly instead of leaving placeholder text telling the reader to "tell them where to go".

The response expectations are deliberately soft (acknowledgement within a week, stated as a target rather than a guarantee) since this is a solo-maintained template. Tighten them if you would rather commit to something firmer.
