### PR TITLE
docs(ci): correct why the weekly audit schedule exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,20 @@ name: CI
 # advisories published on ~2026-07-21 sat undetected until a human push on
 # 07-25 happened to run the audit.
 #
-# Dependabot alerts now catch most of this on their own, but not the case where
-# no fix exists for it to open a PR with. This is the backstop for that.
+# Dependabot alerts catch some of this on their own, but the schedule is the
+# only detector for a whole class it structurally cannot file: a vulnerable
+# TRANSITIVE dependency whose parent needs no update. For npm, Dependabot fixes
+# those by bumping the parent or dropping the sub-dependency, and when neither
+# applies, the fix is a lockfile-only bump of a package that appears in no
+# manifest, which it will not open a PR for. Observed twice here. GHSA-2v37-7h3g
+# -55p8 (nanoid, via @tailwindcss/postcss > postcss) produced an alert on
+# 2026-08-12 and no PR; this schedule caught it on 08-13. The postcss advisories
+# on 07-25 went the same way and were fixed by hand in #174, which is what the
+# `pnpm.overrides` block in the root package.json is. Meanwhile `next` and
+# `sharp` sit in a manifest and got security PRs within a minute of their alerts.
+# In a monorepo most dependencies are transitive, so this is the common case,
+# not the edge one.
+#
 # Dependabot lands its batch on Sunday, so run midweek to halve the worst-case
 # window. The minute is offset because GitHub delays scheduled runs that are
 # queued on the hour.


### PR DESCRIPTION
Comment-only change to `.github/workflows/ci.yml`. No behaviour change.

## The claim that was wrong

> Dependabot alerts now catch most of this on their own, but not the case where no fix exists for it to open a PR with. This is the backstop for that.

A fix did exist for the advisory this schedule just caught. `nanoid@3.3.17` was published, and `postcss@8.5.23` already declares `nanoid: ^3.3.16`, so the patched release fit inside the existing range with no parent bump required. Dependabot filed nothing anyway.

## The real reason

`nanoid` is transitive and appears in no manifest. For npm, Dependabot resolves a vulnerable transitive dependency by bumping the parent or dropping an unnecessary sub-dependency. Neither applies here: the parent needed no update, and `nanoid` is a required runtime dependency of `postcss`. What remains is a lockfile-only bump of a package with no manifest entry, which it does not raise PRs for.

Observed twice in this repo, and the contrast is clean:

| Package | In a manifest? | Security PR? |
|---|---|---|
| `next` | `apps/web/package.json` | yes, #171 / #173, within a minute of the alert |
| `sharp` | `apps/web/package.json` | yes, #172 |
| `postcss` | no (pre-override) | never |
| `nanoid` | no | never |

The postcss advisories on 2026-07-25 went the same way and were fixed by hand in #174. That is where the `pnpm.overrides` block in the root `package.json` came from.

## Why bother rewriting a comment

In a monorepo almost nothing is a direct dependency, so transitive-only advisories are the common case, not the edge. The old wording described a rare situation and made the schedule look like belt-and-braces that a future reader could safely delete. It is closer to the only detector for this class.

Ruled out while investigating, so nobody re-checks them: `cooldown` (applies to version updates only, per GitHub's options reference), the `ignore` wildcard in `dependabot.yml`, and security updates being disabled. All three are disproven by #171, #172, and #173 existing.
